### PR TITLE
prevent Windows paths form getting striped

### DIFF
--- a/todo.py
+++ b/todo.py
@@ -297,7 +297,7 @@ def get_config(config_name="", dir_name=""):
         not config_name:
         default_config()
     else:
-        strip_re = re.compile('\w+\s([A-Za-z_$="./01]+).*')
+        strip_re = re.compile('\w+\s([A-Za-z_$="./01\\\\:]+).*')
         pri_re = re.compile('(PRI_[A-X]|DEFAULT)')
 
         for line in _iter_actual_lines_(config_file):


### PR DESCRIPTION
per #6 prevent windows paths form getting striped to their drive letter.

prevent  this `export TODO_FILE="E:\Dropbox\todo\todo.txt"`

from being treated like it said this `export TODO_FILE="E"`
